### PR TITLE
Update #1 (bump dep versions & enforce trailing slash)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const debug = require('debug')('koa-66');
-const pathToRegexp = require('path-to-regexp');
+const { pathToRegexp } = require('path-to-regexp');
 const compose = require('koa-compose');
 const util = require('util');
 

--- a/index.js
+++ b/index.js
@@ -268,6 +268,7 @@ class Koa66 {
                 throw new TypeError('middleware must be a function');
 
             const keys = [];
+            if(path === "/") path = /\//
             path = (!path || path === '(.*)' || util.isRegExp(path)) ? path : this.sanitizePath(path);
             const regexp = pathToRegexp(path, keys);
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "author": "blaz <blaz@menems.net>",
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.2.0",
-    "koa-compose": "^3.0.0",
-    "path-to-regexp": "^1.2.1"
+    "debug": "4.3.4",
+    "koa-compose": "4.1.0",
+    "path-to-regexp": "6.2.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.0",


### PR DESCRIPTION
I updated all dependencies to the latest version as I saw no issue in doing so (just `path-to-regexp` required a minor change).

Other than that...
https://github.com/welocalize/koa-66/blob/7adaf03209c4730cc3c5b3f9a9b09245c2851748/index.js#L271
...this might be the magic change we were looking for. Without the need to modify all route definitions to use the required slash regex.

By doing this here we also take advantage of the sanitization process koa-66 does:
https://github.com/welocalize/koa-66/blob/7adaf03209c4730cc3c5b3f9a9b09245c2851748/index.js#L229-L236

Getting rid of a possible double slash issue for example.

Tests:

- Using /v1/project will result in 404 (instead of previous 500)
![image](https://github.com/welocalize/koa-66/assets/15463760/ea088a43-09a3-46e9-9e92-b40bc1ecc57b)

- Using /v1/project/ (notice trailing slash) will work
![image](https://github.com/welocalize/koa-66/assets/15463760/fbbd5b01-3735-4d4b-845c-e8a94159514b)

- Using an url with more parts won't require the trailing slash
![image](https://github.com/welocalize/koa-66/assets/15463760/04305b24-00aa-4881-a6d9-810a59b95bb0)

- Will also work with the trailing slash
![image](https://github.com/welocalize/koa-66/assets/15463760/92b8737a-345f-475c-8450-d7bba83b17fc)

Happy path is working!
